### PR TITLE
Fix client animation cycle not being in sync with server's

### DIFF
--- a/mp/src/game/client/hl2mp/c_hl2mp_player.h
+++ b/mp/src/game/client/hl2mp/c_hl2mp_player.h
@@ -87,6 +87,12 @@ public:
 	void DoAnimationEvent( PlayerAnimEvent_t event, int nData = 0 );
 	virtual void CalculateIKLocks( float currentTime );
 
+
+	static void RecvProxy_CycleLatch( const CRecvProxyData *pData, void *pStruct, void *pOut );
+
+	virtual float GetServerIntendedCycle() { return m_flServerCycle; }
+	virtual void SetServerIntendedCycle( float cycle ) { m_flServerCycle = cycle; }
+
 private:
 	
 	C_HL2MP_Player( const C_HL2MP_Player & );
@@ -127,6 +133,9 @@ private:
 	CNetworkVar( HL2MPPlayerState, m_iPlayerState );	
 
 	bool m_fIsWalking;
+
+	int m_cycleLatch; // The animation cycle goes out of sync very easily. Mostly from the player entering/exiting PVS. Server will frequently update us with a new one.
+	float m_flServerCycle;
 };
 
 inline C_HL2MP_Player *ToHL2MPPlayer( CBaseEntity *pEntity )

--- a/mp/src/game/server/hl2mp/hl2mp_player.h
+++ b/mp/src/game/server/hl2mp/hl2mp_player.h
@@ -169,6 +169,9 @@ private:
 
 	bool m_bEnterObserver;
 	bool m_bReady;
+
+	CNetworkVar( int, m_cycleLatch ); // Network the cycle to clients periodically
+	CountdownTimer m_cycleLatchTimer;
 };
 
 inline CHL2MP_Player *ToHL2MPPlayer( CBaseEntity *pEntity )


### PR DESCRIPTION
The client animation cycle goes out of sync with server's very easily, due to the player entering/exiting local player's PVS or by some other mishap. This will cause lag compensation to not work as intended.
This fix exists in other Source games. [CSS & L4D2](https://wiki.alliedmods.net/Left_4_Dead_2_Netprops) for sure. (search m_cycleLatch)

I don't mind if this doesn't get merged, but it's important that people, who use the code, see this fix.

**This PR is not tested with this fork.** I was unable to get the game running without crashing with this fork.
It is fairly easy to replicate, though. Use anim_showstate on a bot (this is not applied to local player) and use host_timescale to slow it down.